### PR TITLE
Fix crash in parsing invalid IPV6

### DIFF
--- a/uri.go
+++ b/uri.go
@@ -534,8 +534,8 @@ func parseAuthority(hier string) (*authorityInfo, error) {
 			// ipv6 addresses: "[" xx:yy:zz "]":port
 			rawHost := host
 			closingbracket := strings.IndexByte(host, ']')
-			if closingbracket > 0 {
-				host = host[bracket+1 : closingbracket-bracket]
+			if closingbracket > bracket+1 {
+				host = host[bracket+1 : closingbracket]
 				rawHost = rawHost[closingbracket+1:]
 			} else {
 				return nil, ErrInvalidURI

--- a/uri_test.go
+++ b/uri_test.go
@@ -305,6 +305,7 @@ func TestMoreURI(t *testing.T) {
 		"inv;alidscheme://www.example.com",
 		"http://www.example.org/hello/world.txt/?id=5&pa{}rt=three#there-you-go", // invalid char in query
 		"http://www.example.org/hello/world.txt/?id=5&part=three#there-you-go{}", // invalid char in fragment
+		"scheme://user:passwd@[]/invalid",                                        // empty IPV6
 	}
 	validURIs := []string{
 		"urn://example-bin.org/path",


### PR DESCRIPTION
Mentioned in fyne-io/fyne#3286